### PR TITLE
Check if account has documents

### DIFF
--- a/src/Result/Merchant/Get.php
+++ b/src/Result/Merchant/Get.php
@@ -37,10 +37,12 @@ class Get extends Merchant
             }
         }
         foreach ($this->data['accounts'] as $account) {
-            foreach ($account['documents'] as $document) {
-                if (!in_array($document['status_id'], array(2, 3))) {
-                    $document['type_name'] .= ' - ' . $account['name'];
-                    array_push($result, $document);
+            if($account['documents']){
+                foreach ($account['documents'] as $document) {
+                    if (!in_array($document['status_id'], array(2, 3))) {
+                        $document['type_name'] .= ' - ' . $account['name'];
+                        array_push($result, $document);
+                    }
                 }
             }
         }


### PR DESCRIPTION
If an account doesn't require documents the api returns an empty string. This change will do a check first before looping over the array.

Fixes #21