### PR TITLE
fix: Use packageType instead of unknown packageName array key

### DIFF
--- a/src/Result/Merchant/Merchant.php
+++ b/src/Result/Merchant/Merchant.php
@@ -23,9 +23,17 @@ class Merchant extends Result
         return $this->data['merchantName'];
     }
 
+    /**
+     * @deprecated use getPackageType() instead.
+     */
     public function getPackageName()
     {
-        return $this->data['packageName'];
+        return $this->data['packageType'];
+    }
+
+    public function getPackageType()
+    {
+        return $this->data['packageType'];
     }
 
     public function getInvoiceAllowed()


### PR DESCRIPTION
# Summary

When using the Merchant result class. The returned value of `packageName()` method responds with `Undefined array key "packageName"`. When using the `getData()` method, the key shows as `packageType`. 

<img width="1171" alt="image" src="https://github.com/paynl/sdk-alliance/assets/143389680/9f52413c-7b09-49f5-9fa7-9b88b549200b">